### PR TITLE
fix: public path to support gh-pages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -192,7 +192,7 @@ module.exports = {
         filename: "[name].js",
         chunkFilename: '[name].[chunkhash:4].js',
         path: outPath,
-        publicPath: "/",
+        publicPath: "./",
     },
     plugins: [
         new HardSourceWebpackPlugin(),


### PR DESCRIPTION
change path from `/` to `./` to support `gh-pages`.
SPA and dist have been served and worked without a problem.