### PR TITLE
chore: rm babel-cjs-plugin - better babel and ts integration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,8 +9,6 @@
     ["@babel/proposal-decorators", { "legacy": true }],
     "@babel/proposal-class-properties",
     "@babel/proposal-object-rest-spread",
-    // in case export default is not defined
-    "@babel/transform-modules-commonjs",
     "lodash"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
       "es2016",
       "es2017.object"
     ],
-    "target": "es5",
-    "module": "commonjs",
+    "target": "es6",
+    "module": "es6",
     "moduleResolution": "node",
     "sourceMap": true
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ const tsLoaderConfig = {
     loader: "ts-loader",
     options: {
         compilerOptions: {
-            module: 'es2015'
+            module: 'es6'
         }
     }
 }


### PR DESCRIPTION
`@babel/transform-modules-commonjs` cause tree shaking not to work.
change ts target since it will transpile with babel any way and babel may handle polyfills better.